### PR TITLE
Compatible with Python3

### DIFF
--- a/blastplus/forms.py
+++ b/blastplus/forms.py
@@ -145,9 +145,9 @@ def validate_sequence(sequence, sequence_is_as_nucleotide=True):
         raise forms.ValidationError(blast_settings.BLAST_CORRECT_SEQ_ERROR_MSG)
 
     if str(sequence).strip()[0] != ">":
-        tmp_seq.write(">seq1\n")
+        tmp_seq.write(">seq1\n".encode())
 
-    tmp_seq.write(sequence)
+    tmp_seq.write(sequence.encode())
     tmp_seq.close()
 
     records = SeqIO.index(tmp_seq.name, "fasta")

--- a/blastplus/templates/blastplus/blast.html
+++ b/blastplus/templates/blastplus/blast.html
@@ -41,7 +41,7 @@
                     $('#loadSampleData').on('click', function () {
                         var $btn = $(this).button('loading');
 
-                        id_sequence_in_form.value = '{{ sequence_sample_in_fasta|escapejs }}';
+                        $("#id_sequence_in_form").val('{{ sequence_sample_in_fasta|escapejs }}');
 
                         $btn.button('reset');
                     });


### PR DESCRIPTION
Modified to be compatible with Python2 and Python3. tempfile.write()
require a bytes-like object as parameter in Python3, while both string
and bytes can be used as parameter in Python2.

Before modification
148         tmp_seq.write(">seq1\n")
150         tmp_seq.write(sequence)
After modification
148         tmp_seq.write(">seq1\n".encode())
150         tmp_seq.write(sequence.encode())